### PR TITLE
Support onnxruntime 1.12.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "terminal.integrated.env.osx": {
         "ORT_STRATEGY": "system",
-        "ORT_LIB_LOCATION": "/usr/local/lib/onnxruntime-1.11.1",
+        "ORT_LIB_LOCATION": "/usr/local/lib/onnxruntime-1.12.0",
     },
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project provides Rust bindings of Microsoft's [onnxruntime](https://github.
 Warning: This project is in very early stage and not finished yet. There are still many bugs as far as I know. Don't use it in production.
 
 ## Prerequisites
-This crate requires you have onnxruntime's C library version v1.11.1 in your system. You can use `initialize_runtime()` to read the C library:
+This crate requires you have onnxruntime's C library version v1.12.0 in your system. You can use `initialize_runtime()` to read the C library:
 
 ```rust
 use ors::api::initialize_runtime;
@@ -14,7 +14,7 @@ fn setup_runtime() {
     #[cfg(target_os = "windows")]
     let path = "/path/to/onnxruntime.dll";
     #[cfg(target_os = "macos")]
-    let path = "/path/to/libonnxruntime.1.11.1.dylib";
+    let path = "/path/to/libonnxruntime.1.12.0.dylib";
     #[cfg(target_os = "linux")]
     let path = "/path/to/libonnxruntime.so";
     initialize_runtime(Path::new(path)).unwrap();
@@ -26,7 +26,7 @@ fn setup_runtime() {
 First, add this crate to your `cargo.toml`
 
 ```toml
-ors = "0.0.9"
+ors = "0.0.12"
 ```
 
 This crate provides `SessionBuilder` which helps you create your inference session. Your don't need to create onnxruntime inference environment, which is handled by this crate:

--- a/ors-sys/build.rs
+++ b/ors-sys/build.rs
@@ -13,7 +13,7 @@ use std::{
 /// WARNING: If version is changed, bindings for all platforms will have to be re-generated.
 ///          To do so, run this:
 ///              cargo build --package ors-sys
-const ORT_VERSION: &str = "1.11.1";
+const ORT_VERSION: &str = "1.12.0";
 
 /// Base Url from which to download pre-built releases/
 const ORT_RELEASE_BASE_URL: &str = "https://github.com/microsoft/onnxruntime/releases/download";
@@ -305,12 +305,12 @@ struct Triplet {
 impl OnnxPrebuiltArchive for Triplet {
     fn as_onnx_str(&self) -> Cow<str> {
         match (&self.os, &self.arch, &self.accelerator) {
-            // onnxruntime-win-x86-1.11.1.zip
-            // onnxruntime-win-x64-1.11.1.zip
-            // onnxruntime-win-arm-1.11.1.zip
-            // onnxruntime-win-arm64-1.11.1.zip
-            // onnxruntime-linux-x64-1.11.1.tgz
-            // onnxruntime-osx-arm64-1.11.1.tgz
+            // onnxruntime-win-x86-1.12.0.zip
+            // onnxruntime-win-x64-1.12.0.zip
+            // onnxruntime-win-arm-1.12.0.zip
+            // onnxruntime-win-arm64-1.12.0.zip
+            // onnxruntime-linux-x64-1.12.0.tgz
+            // onnxruntime-osx-arm64-1.12.0.tgz
             (Os::Windows, Architecture::X86, Accelerator::None)
             | (Os::Windows, Architecture::X86_64, Accelerator::None)
             | (Os::Windows, Architecture::Arm, Accelerator::None)
@@ -321,13 +321,13 @@ impl OnnxPrebuiltArchive for Triplet {
                 self.os.as_onnx_str(),
                 self.arch.as_onnx_str()
             )),
-            // onnxruntime-osx-x86_64-1.11.1.tgz
+            // onnxruntime-osx-x86_64-1.12.0.tgz
             (Os::MacOs, Architecture::X86_64, Accelerator::None) => {
                 Cow::from(format!("{}-{}", self.os.as_onnx_str(), "x86_64"))
             }
 
-            // onnxruntime-win-x64-gpu-1.11.1.zip
-            // onnxruntime-linux-x64-gpu-1.11.1.tgz
+            // onnxruntime-win-x64-gpu-1.12.0.zip
+            // onnxruntime-linux-x64-gpu-1.12.0.tgz
             // Note how this one is inverted from the windows one above
             (Os::Linux, Architecture::X86_64, Accelerator::Gpu)
             | (Os::Windows, Architecture::X86_64, Accelerator::Gpu) => Cow::from(format!(

--- a/ors-sys/src/bindings/linux/x86_64/bindings_dynamic.rs
+++ b/ors-sys/src/bindings/linux/x86_64/bindings_dynamic.rs
@@ -582,7 +582,7 @@ pub const EXIT_SUCCESS: u32 = 0;
 pub const RAND_MAX: u32 = 2147483647;
 pub const _USE_FORTIFY_LEVEL: u32 = 2;
 pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const ORT_API_VERSION: u32 = 11;
+pub const ORT_API_VERSION: u32 = 12;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
@@ -14848,6 +14848,14 @@ pub const OrtErrorCode_ORT_NOT_IMPLEMENTED: OrtErrorCode = 9;
 pub const OrtErrorCode_ORT_INVALID_GRAPH: OrtErrorCode = 10;
 pub const OrtErrorCode_ORT_EP_FAIL: OrtErrorCode = 11;
 pub type OrtErrorCode = ::std::os::raw::c_uint;
+pub const OrtOpAttrType_ORT_OP_ATTR_UNDEFINED: OrtOpAttrType = 0;
+pub const OrtOpAttrType_ORT_OP_ATTR_INT: OrtOpAttrType = 1;
+pub const OrtOpAttrType_ORT_OP_ATTR_INTS: OrtOpAttrType = 2;
+pub const OrtOpAttrType_ORT_OP_ATTR_FLOAT: OrtOpAttrType = 3;
+pub const OrtOpAttrType_ORT_OP_ATTR_FLOATS: OrtOpAttrType = 4;
+pub const OrtOpAttrType_ORT_OP_ATTR_STRING: OrtOpAttrType = 5;
+pub const OrtOpAttrType_ORT_OP_ATTR_STRINGS: OrtOpAttrType = 6;
+pub type OrtOpAttrType = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct OrtEnv {
@@ -14946,6 +14954,16 @@ pub struct OrtTensorRTProviderOptionsV2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct OrtCUDAProviderOptionsV2 {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct OrtOp {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct OrtOpAttr {
     _unused: [u8; 0],
 }
 pub type OrtStatusPtr = *mut OrtStatus;
@@ -15929,12 +15947,16 @@ pub struct OrtOpenVINOProviderOptions {
     pub use_compiled_network: ::std::os::raw::c_uchar,
     pub blob_dump_path: *const ::std::os::raw::c_char,
     pub context: *mut ::std::os::raw::c_void,
+    #[doc = "< 0 = disabled, nonzero = enabled"]
+    pub enable_opencl_throttling: ::std::os::raw::c_uchar,
+    #[doc = "< 0 = disabled, nonzero = enabled"]
+    pub enable_dynamic_shapes: ::std::os::raw::c_uchar,
 }
 #[test]
 fn bindgen_test_layout_OrtOpenVINOProviderOptions() {
     assert_eq!(
         ::std::mem::size_of::<OrtOpenVINOProviderOptions>(),
-        56usize,
+        64usize,
         concat!("Size of: ", stringify!(OrtOpenVINOProviderOptions))
     );
     assert_eq!(
@@ -16061,6 +16083,40 @@ fn bindgen_test_layout_OrtOpenVINOProviderOptions() {
         );
     }
     test_field_context();
+    fn test_field_enable_opencl_throttling() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtOpenVINOProviderOptions>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_opencl_throttling) as usize - ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtOpenVINOProviderOptions),
+                "::",
+                stringify!(enable_opencl_throttling)
+            )
+        );
+    }
+    test_field_enable_opencl_throttling();
+    fn test_field_enable_dynamic_shapes() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtOpenVINOProviderOptions>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_dynamic_shapes) as usize - ptr as usize
+            },
+            57usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtOpenVINOProviderOptions),
+                "::",
+                stringify!(enable_dynamic_shapes)
+            )
+        );
+    }
+    test_field_enable_dynamic_shapes();
 }
 #[doc = " \\brief The helper interface to get the right version of OrtApi"]
 #[doc = ""]
@@ -17397,12 +17453,73 @@ pub struct OrtApi {
             migraphx_options: *const OrtMIGraphXProviderOptions,
         ) -> OrtStatusPtr,
     >,
+    pub AddExternalInitializers: ::std::option::Option<
+        unsafe extern "C" fn(
+            options: *mut OrtSessionOptions,
+            initializer_names: *const *const ::std::os::raw::c_char,
+            initializers: *const *const OrtValue,
+            initializers_num: usize,
+        ) -> OrtStatusPtr,
+    >,
+    pub CreateOpAttr: ::std::option::Option<
+        unsafe extern "C" fn(
+            name: *const ::std::os::raw::c_char,
+            data: *const ::std::os::raw::c_void,
+            len: ::std::os::raw::c_int,
+            type_: OrtOpAttrType,
+            op_attr: *mut *mut OrtOpAttr,
+        ) -> OrtStatusPtr,
+    >,
+    pub ReleaseOpAttr: ::std::option::Option<unsafe extern "C" fn(input: *mut OrtOpAttr)>,
+    pub CreateOp: ::std::option::Option<
+        unsafe extern "C" fn(
+            info: *const OrtKernelInfo,
+            op_name: *const ::std::os::raw::c_char,
+            domain: *const ::std::os::raw::c_char,
+            version: ::std::os::raw::c_int,
+            type_constraint_names: *mut *const ::std::os::raw::c_char,
+            type_constraint_values: *const ONNXTensorElementDataType,
+            type_constraint_count: ::std::os::raw::c_int,
+            attr_values: *const *const OrtOpAttr,
+            attr_count: ::std::os::raw::c_int,
+            input_count: ::std::os::raw::c_int,
+            output_count: ::std::os::raw::c_int,
+            ort_op: *mut *mut OrtOp,
+        ) -> OrtStatusPtr,
+    >,
+    pub InvokeOp: ::std::option::Option<
+        unsafe extern "C" fn(
+            context: *const OrtKernelContext,
+            ort_op: *const OrtOp,
+            input_values: *const *const OrtValue,
+            input_count: ::std::os::raw::c_int,
+            output_values: *const *mut OrtValue,
+            output_count: ::std::os::raw::c_int,
+        ) -> OrtStatusPtr,
+    >,
+    pub ReleaseOp: ::std::option::Option<unsafe extern "C" fn(input: *mut OrtOp)>,
+    pub SessionOptionsAppendExecutionProvider: ::std::option::Option<
+        unsafe extern "C" fn(
+            options: *mut OrtSessionOptions,
+            provider_name: *const ::std::os::raw::c_char,
+            provider_options_keys: *const *const ::std::os::raw::c_char,
+            provider_options_values: *const *const ::std::os::raw::c_char,
+            num_keys: usize,
+        ) -> OrtStatusPtr,
+    >,
+    pub CopyKernelInfo: ::std::option::Option<
+        unsafe extern "C" fn(
+            info: *const OrtKernelInfo,
+            info_copy: *mut *mut OrtKernelInfo,
+        ) -> OrtStatusPtr,
+    >,
+    pub ReleaseKernelInfo: ::std::option::Option<unsafe extern "C" fn(input: *mut OrtKernelInfo)>,
 }
 #[test]
 fn bindgen_test_layout_OrtApi() {
     assert_eq!(
         ::std::mem::size_of::<OrtApi>(),
-        1680usize,
+        1752usize,
         concat!("Size of: ", stringify!(OrtApi))
     );
     assert_eq!(
@@ -21014,6 +21131,160 @@ fn bindgen_test_layout_OrtApi() {
         );
     }
     test_field_SessionOptionsAppendExecutionProvider_MIGraphX();
+    fn test_field_AddExternalInitializers() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).AddExternalInitializers) as usize - ptr as usize
+            },
+            1680usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(AddExternalInitializers)
+            )
+        );
+    }
+    test_field_AddExternalInitializers();
+    fn test_field_CreateOpAttr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).CreateOpAttr) as usize - ptr as usize
+            },
+            1688usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(CreateOpAttr)
+            )
+        );
+    }
+    test_field_CreateOpAttr();
+    fn test_field_ReleaseOpAttr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ReleaseOpAttr) as usize - ptr as usize
+            },
+            1696usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(ReleaseOpAttr)
+            )
+        );
+    }
+    test_field_ReleaseOpAttr();
+    fn test_field_CreateOp() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).CreateOp) as usize - ptr as usize
+            },
+            1704usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(CreateOp)
+            )
+        );
+    }
+    test_field_CreateOp();
+    fn test_field_InvokeOp() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).InvokeOp) as usize - ptr as usize
+            },
+            1712usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(InvokeOp)
+            )
+        );
+    }
+    test_field_InvokeOp();
+    fn test_field_ReleaseOp() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ReleaseOp) as usize - ptr as usize
+            },
+            1720usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(ReleaseOp)
+            )
+        );
+    }
+    test_field_ReleaseOp();
+    fn test_field_SessionOptionsAppendExecutionProvider() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).SessionOptionsAppendExecutionProvider) as usize
+                    - ptr as usize
+            },
+            1728usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(SessionOptionsAppendExecutionProvider)
+            )
+        );
+    }
+    test_field_SessionOptionsAppendExecutionProvider();
+    fn test_field_CopyKernelInfo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).CopyKernelInfo) as usize - ptr as usize
+            },
+            1736usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(CopyKernelInfo)
+            )
+        );
+    }
+    test_field_CopyKernelInfo();
+    fn test_field_ReleaseKernelInfo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ReleaseKernelInfo) as usize - ptr as usize
+            },
+            1744usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(ReleaseKernelInfo)
+            )
+        );
+    }
+    test_field_ReleaseKernelInfo();
 }
 pub const OrtCustomOpInputOutputCharacteristic_INPUT_OUTPUT_REQUIRED:
     OrtCustomOpInputOutputCharacteristic = 0;

--- a/ors-sys/src/bindings/macos/aarch64/bindings_dynamic.rs
+++ b/ors-sys/src/bindings/macos/aarch64/bindings_dynamic.rs
@@ -574,7 +574,7 @@ pub const EXIT_SUCCESS: u32 = 0;
 pub const RAND_MAX: u32 = 2147483647;
 pub const _USE_FORTIFY_LEVEL: u32 = 2;
 pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const ORT_API_VERSION: u32 = 11;
+pub const ORT_API_VERSION: u32 = 12;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
@@ -7128,6 +7128,14 @@ pub const OrtErrorCode_ORT_NOT_IMPLEMENTED: OrtErrorCode = 9;
 pub const OrtErrorCode_ORT_INVALID_GRAPH: OrtErrorCode = 10;
 pub const OrtErrorCode_ORT_EP_FAIL: OrtErrorCode = 11;
 pub type OrtErrorCode = ::std::os::raw::c_uint;
+pub const OrtOpAttrType_ORT_OP_ATTR_UNDEFINED: OrtOpAttrType = 0;
+pub const OrtOpAttrType_ORT_OP_ATTR_INT: OrtOpAttrType = 1;
+pub const OrtOpAttrType_ORT_OP_ATTR_INTS: OrtOpAttrType = 2;
+pub const OrtOpAttrType_ORT_OP_ATTR_FLOAT: OrtOpAttrType = 3;
+pub const OrtOpAttrType_ORT_OP_ATTR_FLOATS: OrtOpAttrType = 4;
+pub const OrtOpAttrType_ORT_OP_ATTR_STRING: OrtOpAttrType = 5;
+pub const OrtOpAttrType_ORT_OP_ATTR_STRINGS: OrtOpAttrType = 6;
+pub type OrtOpAttrType = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct OrtEnv {
@@ -7226,6 +7234,16 @@ pub struct OrtTensorRTProviderOptionsV2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct OrtCUDAProviderOptionsV2 {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct OrtOp {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct OrtOpAttr {
     _unused: [u8; 0],
 }
 pub type OrtStatusPtr = *mut OrtStatus;
@@ -8209,12 +8227,16 @@ pub struct OrtOpenVINOProviderOptions {
     pub use_compiled_network: ::std::os::raw::c_uchar,
     pub blob_dump_path: *const ::std::os::raw::c_char,
     pub context: *mut ::std::os::raw::c_void,
+    #[doc = "< 0 = disabled, nonzero = enabled"]
+    pub enable_opencl_throttling: ::std::os::raw::c_uchar,
+    #[doc = "< 0 = disabled, nonzero = enabled"]
+    pub enable_dynamic_shapes: ::std::os::raw::c_uchar,
 }
 #[test]
 fn bindgen_test_layout_OrtOpenVINOProviderOptions() {
     assert_eq!(
         ::std::mem::size_of::<OrtOpenVINOProviderOptions>(),
-        56usize,
+        64usize,
         concat!("Size of: ", stringify!(OrtOpenVINOProviderOptions))
     );
     assert_eq!(
@@ -8341,6 +8363,40 @@ fn bindgen_test_layout_OrtOpenVINOProviderOptions() {
         );
     }
     test_field_context();
+    fn test_field_enable_opencl_throttling() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtOpenVINOProviderOptions>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_opencl_throttling) as usize - ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtOpenVINOProviderOptions),
+                "::",
+                stringify!(enable_opencl_throttling)
+            )
+        );
+    }
+    test_field_enable_opencl_throttling();
+    fn test_field_enable_dynamic_shapes() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtOpenVINOProviderOptions>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_dynamic_shapes) as usize - ptr as usize
+            },
+            57usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtOpenVINOProviderOptions),
+                "::",
+                stringify!(enable_dynamic_shapes)
+            )
+        );
+    }
+    test_field_enable_dynamic_shapes();
 }
 #[doc = " \\brief The helper interface to get the right version of OrtApi"]
 #[doc = ""]
@@ -9677,12 +9733,73 @@ pub struct OrtApi {
             migraphx_options: *const OrtMIGraphXProviderOptions,
         ) -> OrtStatusPtr,
     >,
+    pub AddExternalInitializers: ::std::option::Option<
+        unsafe extern "C" fn(
+            options: *mut OrtSessionOptions,
+            initializer_names: *const *const ::std::os::raw::c_char,
+            initializers: *const *const OrtValue,
+            initializers_num: usize,
+        ) -> OrtStatusPtr,
+    >,
+    pub CreateOpAttr: ::std::option::Option<
+        unsafe extern "C" fn(
+            name: *const ::std::os::raw::c_char,
+            data: *const ::std::os::raw::c_void,
+            len: ::std::os::raw::c_int,
+            type_: OrtOpAttrType,
+            op_attr: *mut *mut OrtOpAttr,
+        ) -> OrtStatusPtr,
+    >,
+    pub ReleaseOpAttr: ::std::option::Option<unsafe extern "C" fn(input: *mut OrtOpAttr)>,
+    pub CreateOp: ::std::option::Option<
+        unsafe extern "C" fn(
+            info: *const OrtKernelInfo,
+            op_name: *const ::std::os::raw::c_char,
+            domain: *const ::std::os::raw::c_char,
+            version: ::std::os::raw::c_int,
+            type_constraint_names: *mut *const ::std::os::raw::c_char,
+            type_constraint_values: *const ONNXTensorElementDataType,
+            type_constraint_count: ::std::os::raw::c_int,
+            attr_values: *const *const OrtOpAttr,
+            attr_count: ::std::os::raw::c_int,
+            input_count: ::std::os::raw::c_int,
+            output_count: ::std::os::raw::c_int,
+            ort_op: *mut *mut OrtOp,
+        ) -> OrtStatusPtr,
+    >,
+    pub InvokeOp: ::std::option::Option<
+        unsafe extern "C" fn(
+            context: *const OrtKernelContext,
+            ort_op: *const OrtOp,
+            input_values: *const *const OrtValue,
+            input_count: ::std::os::raw::c_int,
+            output_values: *const *mut OrtValue,
+            output_count: ::std::os::raw::c_int,
+        ) -> OrtStatusPtr,
+    >,
+    pub ReleaseOp: ::std::option::Option<unsafe extern "C" fn(input: *mut OrtOp)>,
+    pub SessionOptionsAppendExecutionProvider: ::std::option::Option<
+        unsafe extern "C" fn(
+            options: *mut OrtSessionOptions,
+            provider_name: *const ::std::os::raw::c_char,
+            provider_options_keys: *const *const ::std::os::raw::c_char,
+            provider_options_values: *const *const ::std::os::raw::c_char,
+            num_keys: usize,
+        ) -> OrtStatusPtr,
+    >,
+    pub CopyKernelInfo: ::std::option::Option<
+        unsafe extern "C" fn(
+            info: *const OrtKernelInfo,
+            info_copy: *mut *mut OrtKernelInfo,
+        ) -> OrtStatusPtr,
+    >,
+    pub ReleaseKernelInfo: ::std::option::Option<unsafe extern "C" fn(input: *mut OrtKernelInfo)>,
 }
 #[test]
 fn bindgen_test_layout_OrtApi() {
     assert_eq!(
         ::std::mem::size_of::<OrtApi>(),
-        1680usize,
+        1752usize,
         concat!("Size of: ", stringify!(OrtApi))
     );
     assert_eq!(
@@ -13294,6 +13411,160 @@ fn bindgen_test_layout_OrtApi() {
         );
     }
     test_field_SessionOptionsAppendExecutionProvider_MIGraphX();
+    fn test_field_AddExternalInitializers() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).AddExternalInitializers) as usize - ptr as usize
+            },
+            1680usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(AddExternalInitializers)
+            )
+        );
+    }
+    test_field_AddExternalInitializers();
+    fn test_field_CreateOpAttr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).CreateOpAttr) as usize - ptr as usize
+            },
+            1688usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(CreateOpAttr)
+            )
+        );
+    }
+    test_field_CreateOpAttr();
+    fn test_field_ReleaseOpAttr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ReleaseOpAttr) as usize - ptr as usize
+            },
+            1696usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(ReleaseOpAttr)
+            )
+        );
+    }
+    test_field_ReleaseOpAttr();
+    fn test_field_CreateOp() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).CreateOp) as usize - ptr as usize
+            },
+            1704usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(CreateOp)
+            )
+        );
+    }
+    test_field_CreateOp();
+    fn test_field_InvokeOp() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).InvokeOp) as usize - ptr as usize
+            },
+            1712usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(InvokeOp)
+            )
+        );
+    }
+    test_field_InvokeOp();
+    fn test_field_ReleaseOp() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ReleaseOp) as usize - ptr as usize
+            },
+            1720usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(ReleaseOp)
+            )
+        );
+    }
+    test_field_ReleaseOp();
+    fn test_field_SessionOptionsAppendExecutionProvider() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).SessionOptionsAppendExecutionProvider) as usize
+                    - ptr as usize
+            },
+            1728usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(SessionOptionsAppendExecutionProvider)
+            )
+        );
+    }
+    test_field_SessionOptionsAppendExecutionProvider();
+    fn test_field_CopyKernelInfo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).CopyKernelInfo) as usize - ptr as usize
+            },
+            1736usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(CopyKernelInfo)
+            )
+        );
+    }
+    test_field_CopyKernelInfo();
+    fn test_field_ReleaseKernelInfo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ReleaseKernelInfo) as usize - ptr as usize
+            },
+            1744usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(ReleaseKernelInfo)
+            )
+        );
+    }
+    test_field_ReleaseKernelInfo();
 }
 pub const OrtCustomOpInputOutputCharacteristic_INPUT_OUTPUT_REQUIRED:
     OrtCustomOpInputOutputCharacteristic = 0;

--- a/ors-sys/src/bindings/macos/x86_64/bindings_dynamic.rs
+++ b/ors-sys/src/bindings/macos/x86_64/bindings_dynamic.rs
@@ -584,7 +584,7 @@ pub const EXIT_SUCCESS: u32 = 0;
 pub const RAND_MAX: u32 = 2147483647;
 pub const _USE_FORTIFY_LEVEL: u32 = 2;
 pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
-pub const ORT_API_VERSION: u32 = 11;
+pub const ORT_API_VERSION: u32 = 12;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
@@ -14850,6 +14850,14 @@ pub const OrtErrorCode_ORT_NOT_IMPLEMENTED: OrtErrorCode = 9;
 pub const OrtErrorCode_ORT_INVALID_GRAPH: OrtErrorCode = 10;
 pub const OrtErrorCode_ORT_EP_FAIL: OrtErrorCode = 11;
 pub type OrtErrorCode = ::std::os::raw::c_uint;
+pub const OrtOpAttrType_ORT_OP_ATTR_UNDEFINED: OrtOpAttrType = 0;
+pub const OrtOpAttrType_ORT_OP_ATTR_INT: OrtOpAttrType = 1;
+pub const OrtOpAttrType_ORT_OP_ATTR_INTS: OrtOpAttrType = 2;
+pub const OrtOpAttrType_ORT_OP_ATTR_FLOAT: OrtOpAttrType = 3;
+pub const OrtOpAttrType_ORT_OP_ATTR_FLOATS: OrtOpAttrType = 4;
+pub const OrtOpAttrType_ORT_OP_ATTR_STRING: OrtOpAttrType = 5;
+pub const OrtOpAttrType_ORT_OP_ATTR_STRINGS: OrtOpAttrType = 6;
+pub type OrtOpAttrType = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct OrtEnv {
@@ -14948,6 +14956,16 @@ pub struct OrtTensorRTProviderOptionsV2 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct OrtCUDAProviderOptionsV2 {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct OrtOp {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct OrtOpAttr {
     _unused: [u8; 0],
 }
 pub type OrtStatusPtr = *mut OrtStatus;
@@ -15931,12 +15949,16 @@ pub struct OrtOpenVINOProviderOptions {
     pub use_compiled_network: ::std::os::raw::c_uchar,
     pub blob_dump_path: *const ::std::os::raw::c_char,
     pub context: *mut ::std::os::raw::c_void,
+    #[doc = "< 0 = disabled, nonzero = enabled"]
+    pub enable_opencl_throttling: ::std::os::raw::c_uchar,
+    #[doc = "< 0 = disabled, nonzero = enabled"]
+    pub enable_dynamic_shapes: ::std::os::raw::c_uchar,
 }
 #[test]
 fn bindgen_test_layout_OrtOpenVINOProviderOptions() {
     assert_eq!(
         ::std::mem::size_of::<OrtOpenVINOProviderOptions>(),
-        56usize,
+        64usize,
         concat!("Size of: ", stringify!(OrtOpenVINOProviderOptions))
     );
     assert_eq!(
@@ -16063,6 +16085,40 @@ fn bindgen_test_layout_OrtOpenVINOProviderOptions() {
         );
     }
     test_field_context();
+    fn test_field_enable_opencl_throttling() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtOpenVINOProviderOptions>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_opencl_throttling) as usize - ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtOpenVINOProviderOptions),
+                "::",
+                stringify!(enable_opencl_throttling)
+            )
+        );
+    }
+    test_field_enable_opencl_throttling();
+    fn test_field_enable_dynamic_shapes() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtOpenVINOProviderOptions>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_dynamic_shapes) as usize - ptr as usize
+            },
+            57usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtOpenVINOProviderOptions),
+                "::",
+                stringify!(enable_dynamic_shapes)
+            )
+        );
+    }
+    test_field_enable_dynamic_shapes();
 }
 #[doc = " \\brief The helper interface to get the right version of OrtApi"]
 #[doc = ""]
@@ -17399,12 +17455,73 @@ pub struct OrtApi {
             migraphx_options: *const OrtMIGraphXProviderOptions,
         ) -> OrtStatusPtr,
     >,
+    pub AddExternalInitializers: ::std::option::Option<
+        unsafe extern "C" fn(
+            options: *mut OrtSessionOptions,
+            initializer_names: *const *const ::std::os::raw::c_char,
+            initializers: *const *const OrtValue,
+            initializers_num: usize,
+        ) -> OrtStatusPtr,
+    >,
+    pub CreateOpAttr: ::std::option::Option<
+        unsafe extern "C" fn(
+            name: *const ::std::os::raw::c_char,
+            data: *const ::std::os::raw::c_void,
+            len: ::std::os::raw::c_int,
+            type_: OrtOpAttrType,
+            op_attr: *mut *mut OrtOpAttr,
+        ) -> OrtStatusPtr,
+    >,
+    pub ReleaseOpAttr: ::std::option::Option<unsafe extern "C" fn(input: *mut OrtOpAttr)>,
+    pub CreateOp: ::std::option::Option<
+        unsafe extern "C" fn(
+            info: *const OrtKernelInfo,
+            op_name: *const ::std::os::raw::c_char,
+            domain: *const ::std::os::raw::c_char,
+            version: ::std::os::raw::c_int,
+            type_constraint_names: *mut *const ::std::os::raw::c_char,
+            type_constraint_values: *const ONNXTensorElementDataType,
+            type_constraint_count: ::std::os::raw::c_int,
+            attr_values: *const *const OrtOpAttr,
+            attr_count: ::std::os::raw::c_int,
+            input_count: ::std::os::raw::c_int,
+            output_count: ::std::os::raw::c_int,
+            ort_op: *mut *mut OrtOp,
+        ) -> OrtStatusPtr,
+    >,
+    pub InvokeOp: ::std::option::Option<
+        unsafe extern "C" fn(
+            context: *const OrtKernelContext,
+            ort_op: *const OrtOp,
+            input_values: *const *const OrtValue,
+            input_count: ::std::os::raw::c_int,
+            output_values: *const *mut OrtValue,
+            output_count: ::std::os::raw::c_int,
+        ) -> OrtStatusPtr,
+    >,
+    pub ReleaseOp: ::std::option::Option<unsafe extern "C" fn(input: *mut OrtOp)>,
+    pub SessionOptionsAppendExecutionProvider: ::std::option::Option<
+        unsafe extern "C" fn(
+            options: *mut OrtSessionOptions,
+            provider_name: *const ::std::os::raw::c_char,
+            provider_options_keys: *const *const ::std::os::raw::c_char,
+            provider_options_values: *const *const ::std::os::raw::c_char,
+            num_keys: usize,
+        ) -> OrtStatusPtr,
+    >,
+    pub CopyKernelInfo: ::std::option::Option<
+        unsafe extern "C" fn(
+            info: *const OrtKernelInfo,
+            info_copy: *mut *mut OrtKernelInfo,
+        ) -> OrtStatusPtr,
+    >,
+    pub ReleaseKernelInfo: ::std::option::Option<unsafe extern "C" fn(input: *mut OrtKernelInfo)>,
 }
 #[test]
 fn bindgen_test_layout_OrtApi() {
     assert_eq!(
         ::std::mem::size_of::<OrtApi>(),
-        1680usize,
+        1752usize,
         concat!("Size of: ", stringify!(OrtApi))
     );
     assert_eq!(
@@ -21016,6 +21133,160 @@ fn bindgen_test_layout_OrtApi() {
         );
     }
     test_field_SessionOptionsAppendExecutionProvider_MIGraphX();
+    fn test_field_AddExternalInitializers() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).AddExternalInitializers) as usize - ptr as usize
+            },
+            1680usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(AddExternalInitializers)
+            )
+        );
+    }
+    test_field_AddExternalInitializers();
+    fn test_field_CreateOpAttr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).CreateOpAttr) as usize - ptr as usize
+            },
+            1688usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(CreateOpAttr)
+            )
+        );
+    }
+    test_field_CreateOpAttr();
+    fn test_field_ReleaseOpAttr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ReleaseOpAttr) as usize - ptr as usize
+            },
+            1696usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(ReleaseOpAttr)
+            )
+        );
+    }
+    test_field_ReleaseOpAttr();
+    fn test_field_CreateOp() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).CreateOp) as usize - ptr as usize
+            },
+            1704usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(CreateOp)
+            )
+        );
+    }
+    test_field_CreateOp();
+    fn test_field_InvokeOp() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).InvokeOp) as usize - ptr as usize
+            },
+            1712usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(InvokeOp)
+            )
+        );
+    }
+    test_field_InvokeOp();
+    fn test_field_ReleaseOp() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ReleaseOp) as usize - ptr as usize
+            },
+            1720usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(ReleaseOp)
+            )
+        );
+    }
+    test_field_ReleaseOp();
+    fn test_field_SessionOptionsAppendExecutionProvider() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).SessionOptionsAppendExecutionProvider) as usize
+                    - ptr as usize
+            },
+            1728usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(SessionOptionsAppendExecutionProvider)
+            )
+        );
+    }
+    test_field_SessionOptionsAppendExecutionProvider();
+    fn test_field_CopyKernelInfo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).CopyKernelInfo) as usize - ptr as usize
+            },
+            1736usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(CopyKernelInfo)
+            )
+        );
+    }
+    test_field_CopyKernelInfo();
+    fn test_field_ReleaseKernelInfo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OrtApi>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ReleaseKernelInfo) as usize - ptr as usize
+            },
+            1744usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OrtApi),
+                "::",
+                stringify!(ReleaseKernelInfo)
+            )
+        );
+    }
+    test_field_ReleaseKernelInfo();
 }
 pub const OrtCustomOpInputOutputCharacteristic_INPUT_OUTPUT_REQUIRED:
     OrtCustomOpInputOutputCharacteristic = 0;

--- a/ors/src/api.rs
+++ b/ors/src/api.rs
@@ -37,7 +37,7 @@ pub fn initialize_runtime(path: &Path) -> Result<()> {
     // Otherwise, load onnxruntime shared library
     let mut ort = match unsafe { onnxruntime::new(path) } {
         Ok(ort) => ManuallyDrop::new(ort),
-        Err(err) => return Err(anyhow!("Failed to load onnxruntime shared library")),
+        Err(err) => return Err(anyhow!("Failed to load onnxruntime shared library {}", err)),
     };
 
     // Wrap the lib using ManuallyDrop
@@ -156,7 +156,7 @@ mod test {
         #[cfg(target_os = "windows")]
         let path = "D:\\Projects\\Rust\\ors\\onnxruntime.dll";
         #[cfg(target_os = "macos")]
-        let path = "/usr/local/lib/libonnxruntime.1.11.1.dylib";
+        let path = "/usr/local/lib/libonnxruntime.1.12.0.dylib";
         #[cfg(target_os = "linux")]
         let path = "/usr/local/lib/libonnxruntime.so";
         initialize_runtime(Path::new(path)).expect("Failed to initialize runtime");

--- a/ors/src/env.rs
+++ b/ors/src/env.rs
@@ -65,7 +65,7 @@ mod test {
         #[cfg(target_os = "windows")]
         let path = "D:\\Projects\\Rust\\ors\\onnxruntime.dll";
         #[cfg(target_os = "macos")]
-        let path = "/usr/local/lib/libonnxruntime.1.11.1.dylib";
+        let path = "/usr/local/lib/libonnxruntime.1.12.0.dylib";
         #[cfg(target_os = "linux")]
         let path = "/usr/local/lib/libonnxruntime.so";
         initialize_runtime(Path::new(path)).unwrap();

--- a/ors/src/lib.rs
+++ b/ors/src/lib.rs
@@ -32,7 +32,7 @@ mod tests {
         #[cfg(target_os = "windows")]
         let path = "D:\\Projects\\Rust\\ors\\onnxruntime.dll";
         #[cfg(target_os = "macos")]
-        let path = "/usr/local/lib/libonnxruntime.1.11.1.dylib";
+        let path = "/usr/local/lib/libonnxruntime.1.12.0.dylib";
         #[cfg(target_os = "linux")]
         let path = "/usr/local/lib/libonnxruntime.so";
         initialize_runtime(Path::new(path)).unwrap();

--- a/ors/src/memory_info.rs
+++ b/ors/src/memory_info.rs
@@ -67,7 +67,7 @@ mod tests {
         #[cfg(target_os = "windows")]
         let path = "D:\\Projects\\Rust\\ors\\onnxruntime.dll";
         #[cfg(target_os = "macos")]
-        let path = "/usr/local/lib/libonnxruntime.1.11.1.dylib";
+        let path = "/usr/local/lib/libonnxruntime.1.12.0.dylib";
         #[cfg(target_os = "linux")]
         let path = "/usr/local/lib/libonnxruntime.so";
         initialize_runtime(Path::new(path)).unwrap();

--- a/ors/src/session.rs
+++ b/ors/src/session.rs
@@ -389,7 +389,7 @@ mod test {
         #[cfg(target_os = "windows")]
         let path = "D:\\Projects\\Rust\\ors\\onnxruntime.dll";
         #[cfg(target_os = "macos")]
-        let path = "/usr/local/lib/libonnxruntime.1.11.1.dylib";
+        let path = "/usr/local/lib/libonnxruntime.1.12.0.dylib";
         #[cfg(target_os = "linux")]
         let path = "/usr/local/lib/libonnxruntime.so";
         initialize_runtime(Path::new(path)).unwrap();

--- a/ors/src/status.rs
+++ b/ors/src/status.rs
@@ -63,7 +63,7 @@ mod test {
         #[cfg(target_os = "windows")]
         let path = "D:\\Projects\\Rust\\ors\\onnxruntime.dll";
         #[cfg(target_os = "macos")]
-        let path = "/usr/local/lib/libonnxruntime.1.11.1.dylib";
+        let path = "/usr/local/lib/libonnxruntime.1.12.0.dylib";
         #[cfg(target_os = "linux")]
         let path = "/usr/local/lib/libonnxruntime.so";
         initialize_runtime(Path::new(path)).unwrap();

--- a/ors/src/tensor.rs
+++ b/ors/src/tensor.rs
@@ -220,7 +220,7 @@ mod test {
         #[cfg(target_os = "windows")]
         let path = "D:\\Projects\\Rust\\ors\\onnxruntime.dll";
         #[cfg(target_os = "macos")]
-        let path = "/usr/local/lib/libonnxruntime.1.11.1.dylib";
+        let path = "/usr/local/lib/libonnxruntime.1.12.0.dylib";
         #[cfg(target_os = "linux")]
         let path = "/usr/local/lib/libonnxruntime.so";
         initialize_runtime(Path::new(path)).unwrap();


### PR DESCRIPTION
onnxruntime 1.12.0 haven't been released, this PR is based on the lib compiled by onnxruntime latest master.

bindings:
- [x] linux
- [x] macos
- [x] macos arm64
- [ ] windows


Signed-off-by: HaoboGu <haobogu@outlook.com>